### PR TITLE
EASE-25921:  Add cctools to compile on linux

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "cctools"]
+	path = cctools
+	url = git@github.com:apperian/cctools.git

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 CC := gcc
-ARCHS := -arch i386 -arch x86_64
-CFLAGS := -c -std=c99 -O2 -pedantic -Wall -Wextra $(ARCHS) -D_LARGEFILE_SOURCE -D_FILE_OFFSET_BITS=64
+ARCHS := -m64
+CFLAGS := -c -std=c99 -O2 -pedantic -I cctools/include -Wall -Wextra $(ARCHS) -D_LARGEFILE_SOURCE -D_FILE_OFFSET_BITS=64
 LD := gcc
 LDFLAGS := $(ARCHS)
 


### PR DESCRIPTION
Include cctools as a submodule to get unsign building on linux.