### PR TITLE
Fix for Mojave/Catalina. Don't build for i386 on those since it's not supported

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,15 @@
 CC := gcc
+
+DARWIN_VERSION := $(shell sw_vers -productVersion)
+DARWIN_MOJAVE_AND_UP := $(shell expr $(DARWIN_VERSION) \>= 10.14)
+
+# don't build for i386 on Mojave and up...
+ifeq ($(DARWIN_MOJAVE_AND_UP),1)
+ARCHS := -arch x86_64
+else
 ARCHS := -arch i386 -arch x86_64
+endif
+
 CFLAGS := -c -std=c99 -O2 -pedantic -Wall -Wextra $(ARCHS) -D_LARGEFILE_SOURCE -D_FILE_OFFSET_BITS=64
 LD := gcc
 LDFLAGS := $(ARCHS)


### PR DESCRIPTION
This fixes #8 

Tested on Catalina. I admit I haven't tested on a pre-Mojave machine but it should work just like it did before.
